### PR TITLE
Feature/admin stats dashboard

### DIFF
--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -8,6 +8,30 @@ from django.utils.translation import gettext_lazy as _
 
 from core import models
 
+from django.urls import path
+import json
+from typing import Optional, Dict, Any
+from django.http import HttpRequest, HttpResponse
+from django.urls.resolvers import URLPattern
+from core.statistics import (
+    get_user_field_of_study_stats,
+    get_most_consulted_documents_stats,
+    get_most_consulted_authors_stats,
+    get_document_keywords_stats,
+    get_user_education_level_stats,
+    get_user_activity_status_stats,
+    get_chats_over_time_stats,
+)
+from core.export_stats import (
+    export_user_field_of_study_csv,
+    export_user_education_level_csv,
+    export_user_activity_status_csv,
+    export_most_consulted_documents_csv,
+    export_most_consulted_authors_csv,
+    export_document_keywords_csv,
+    export_chats_over_time_csv,
+)
+
 
 class UserAdmin(BaseUserAdmin):
     """
@@ -56,6 +80,40 @@ class UserAdmin(BaseUserAdmin):
         }),
     )
 
+    def changelist_view(
+            self, request: HttpRequest,
+            extra_context: Optional[Dict[str, Any]] = None) -> HttpResponse:
+        """
+        Customize the changelist view to include statistics in
+        the admin template context.
+        """
+        extra_context = extra_context or {}
+        extra_context['user_stats_data'] = json.dumps(
+            get_user_field_of_study_stats())
+        extra_context['user_edu_level_data'] = json.dumps(
+            get_user_education_level_stats())
+        extra_context['user_activity_status_data'] = json.dumps(
+            get_user_activity_status_stats())
+        return super().changelist_view(request, extra_context=extra_context)
+
+    def get_urls(self) -> list[URLPattern]:
+        """
+        Add custom admin URLs for exporting statistics to CSV.
+        """
+        urls = super().get_urls()
+        custom_urls = [
+            path('export-field-of-study-csv/', self.admin_site.admin_view(
+                export_user_field_of_study_csv),
+                name='user_field_of_study_stats_export'),
+            path('export-education-level-csv/', self.admin_site.admin_view(
+                export_user_education_level_csv),
+                name='user_education_level_stats_export'),
+            path('export-activity-status-csv/', self.admin_site.admin_view(
+                export_user_activity_status_csv),
+                name='user_activity_status_stats_export'),
+        ]
+        return custom_urls + urls
+
 
 class DocumentAdmin(admin.ModelAdmin):
     """
@@ -65,7 +123,7 @@ class DocumentAdmin(admin.ModelAdmin):
     list_display = ['title', 'created_at', 'status']
     list_filter = ['status']
     fieldsets = (
-        (None, {'fields': ('title',)}),
+        (None, {'fields': ('id', 'title',)}),
         (
             _('Important dates'),
             {
@@ -87,6 +145,30 @@ class DocumentAdmin(admin.ModelAdmin):
     )
     readonly_fields = ['created_at', 'updated_at']
 
+    def changelist_view(
+            self, request: HttpRequest,
+            extra_context: Optional[Dict[str, Any]] = None) -> HttpResponse:
+        """
+        Customize the changelist view to include statistics in
+        the admin template context.
+        """
+        extra_context = extra_context or {}
+        extra_context['document_keywords_data'] = json.dumps(
+            get_document_keywords_stats())
+        return super().changelist_view(request, extra_context)
+
+    def get_urls(self) -> list[URLPattern]:
+        """
+        Add custom admin URLs for exporting statistics to CSV.
+        """
+        urls = super().get_urls()
+        custom_urls = [
+            path('export-document-keywords-csv/', self.admin_site.admin_view(
+                export_document_keywords_csv),
+                name='document_keywords_stats_export'),
+        ]
+        return custom_urls + urls
+
 
 class AuthoredDocumentAdmin(admin.ModelAdmin):
     """
@@ -104,6 +186,30 @@ class AuthoredDocumentAdmin(admin.ModelAdmin):
         }),
     )
     readonly_fields = ['created_at']
+
+    def changelist_view(
+            self, request: HttpRequest,
+            extra_context: Optional[Dict[str, Any]] = None) -> HttpResponse:
+        """
+        Customize the changelist view to include statistics in
+        the admin template context.
+        """
+        extra_context = extra_context or {}
+        extra_context['author_stats_data'] = json.dumps(
+            get_most_consulted_authors_stats())
+        return super().changelist_view(request, extra_context)
+
+    def get_urls(self) -> list[URLPattern]:
+        """
+        Add custom admin URLs for exporting statistics to CSV.
+        """
+        urls = super().get_urls()
+        custom_urls = [
+            path('export-authors-csv/', self.admin_site.admin_view(
+                export_most_consulted_authors_csv),
+                name='most_consulted_authors_stats_export'),
+        ]
+        return custom_urls + urls
 
 
 class SavedDocumentAdmin(admin.ModelAdmin):
@@ -123,6 +229,30 @@ class SavedDocumentAdmin(admin.ModelAdmin):
     )
     readonly_fields = ['created_at']
 
+    def changelist_view(
+            self, request: HttpRequest,
+            extra_context: Optional[Dict[str, Any]] = None) -> HttpResponse:
+        """
+        Customize the changelist view to include statistics in
+        the admin template context.
+        """
+        extra_context = extra_context or {}
+        extra_context['document_stats_data'] = json.dumps(
+            get_most_consulted_documents_stats())
+        return super().changelist_view(request, extra_context=extra_context)
+
+    def get_urls(self) -> list[URLPattern]:
+        """
+        Add custom admin URLs for exporting statistics to CSV.
+        """
+        urls = super().get_urls()
+        custom_urls = [
+            path('export-documents-csv/', self.admin_site.admin_view(
+                export_most_consulted_documents_csv),
+                name='most_consulted_documents_stats_export'),
+        ]
+        return custom_urls + urls
+
 
 class ChatSessionAdmin(admin.ModelAdmin):
     """
@@ -141,6 +271,30 @@ class ChatSessionAdmin(admin.ModelAdmin):
     )
     readonly_fields = ['created_at', 'updated_at']
     search_fields = ['session_name', 'assistant_id', 'user__email']
+
+    def changelist_view(
+            self, request: HttpRequest,
+            extra_context: Optional[Dict[str, Any]] = None) -> HttpResponse:
+        """
+        Customize the changelist view to include statistics in
+        the admin template context.
+        """
+        extra_context = extra_context or {}
+        extra_context['sessions_by_day'] = json.dumps(
+            get_chats_over_time_stats())
+        return super().changelist_view(request, extra_context=extra_context)
+
+    def get_urls(self) -> list[URLPattern]:
+        """
+        Add custom admin URLs for exporting statistics to CSV.
+        """
+        urls = super().get_urls()
+        custom_urls = [
+            path('export-chats-csv/', self.admin_site.admin_view(
+                export_chats_over_time_csv),
+                name='chats_over_time_stats_export'),
+        ]
+        return custom_urls + urls
 
 
 admin.site.register(models.User, UserAdmin)

--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -62,7 +62,8 @@ class DocumentAdmin(admin.ModelAdmin):
     Define the admin pages for documents.
     """
     ordering = ['id']
-    list_display = ['title', 'created_at']
+    list_display = ['title', 'created_at', 'status']
+    list_filter = ['status']
     fieldsets = (
         (None, {'fields': ('title',)}),
         (
@@ -93,6 +94,7 @@ class AuthoredDocumentAdmin(admin.ModelAdmin):
     """
     ordering = ['-created_at']
     list_display = ['author', 'document', 'created_at']
+    list_filter = ['author']
     fieldsets = (
         (None, {
             'fields': ('author', 'document')
@@ -110,6 +112,7 @@ class SavedDocumentAdmin(admin.ModelAdmin):
     """
     ordering = ['-created_at']
     list_display = ['user', 'document', 'created_at']
+    list_filter = ['user']
     fieldsets = (
         (None, {
             'fields': ('user', 'document')
@@ -127,6 +130,7 @@ class ChatSessionAdmin(admin.ModelAdmin):
     """
     ordering = ['-created_at']
     list_display = ['user', 'session_name', 'created_at', 'updated_at']
+    list_filter = ['user']
     fieldsets = (
         (None, {
             'fields': ('session_id', 'session_name', 'user', 'assistant_id')

--- a/src/core/export_stats.py
+++ b/src/core/export_stats.py
@@ -1,0 +1,141 @@
+"""
+Export statistics to CSV files.
+"""
+import csv
+from django.http import HttpRequest, HttpResponse
+from core.statistics import (get_user_field_of_study_stats,
+                             get_most_consulted_documents_stats,
+                             get_most_consulted_authors_stats,
+                             get_document_keywords_stats,
+                             get_user_education_level_stats,
+                             get_user_activity_status_stats,
+                             get_chats_over_time_stats,
+                             )
+
+
+def export_user_field_of_study_csv(request: HttpRequest) -> HttpResponse:
+    """
+    Export user field of study statistics to a CSV file.
+    """
+    data = get_user_field_of_study_stats()
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename=user_\
+        field_of_study_stats.csv'
+    writer = csv.writer(response)
+    writer.writerow(['Category', 'Field', 'Count'])
+
+    labels = data['labels']
+    values = data['values']
+
+    for label, value in zip(labels, values):
+        writer.writerow(['user_field_of_study', label, value])
+
+    return response
+
+
+def export_user_education_level_csv(request: HttpRequest) -> HttpResponse:
+    """
+    Export user education level statistics to a CSV file.
+    """
+    data = get_user_education_level_stats()
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename=user_\
+        education_level_stats.csv'
+    writer = csv.writer(response)
+    writer.writerow(['Category', 'Field', 'Count'])
+
+    labels = data['labels']
+    values = data['values']
+
+    for label, value in zip(labels, values):
+        writer.writerow(['user_education_level', label, value])
+
+    return response
+
+
+def export_user_activity_status_csv(request: HttpRequest) -> HttpResponse:
+    """
+    Export user activity status statistics to a CSV file.
+    """
+    data = get_user_activity_status_stats()
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename=\
+        user_activity_status_stats.csv'
+    writer = csv.writer(response)
+    writer.writerow(['Category', 'Field', 'Count'])
+
+    labels = data['labels']
+    values = data['values']
+
+    for label, value in zip(labels, values):
+        writer.writerow(['user_activity_status', label, value])
+
+    return response
+
+
+def export_most_consulted_documents_csv(request: HttpRequest) -> HttpResponse:
+    """
+    Export most consulted documents statistics to a CSV file.
+    """
+    data = get_most_consulted_documents_stats()
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename=most_\
+        consulted_documents.csv'
+    writer = csv.writer(response)
+    writer.writerow(['Category', 'Title', 'Count'])
+
+    for label, value in zip(data['labels'], data['values']):
+        writer.writerow(['most_consulted_documents', label, value])
+
+    return response
+
+
+def export_most_consulted_authors_csv(request: HttpRequest) -> HttpResponse:
+    """
+    Export most consulted authors statistics to a CSV file.
+    """
+    data = get_most_consulted_authors_stats()
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename=most_\
+        consulted_authors.csv'
+    writer = csv.writer(response)
+    writer.writerow(['Category', 'Author', 'Count'])
+
+    for label, value in zip(data['labels'], data['values']):
+        writer.writerow(['most_consulted_authors', label, value])
+
+    return response
+
+
+def export_document_keywords_csv(request: HttpRequest) -> HttpResponse:
+    """
+    Export document keyword statistics to a CSV file.
+    """
+    data = get_document_keywords_stats()
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename=document\
+        _keywords.csv'
+    writer = csv.writer(response)
+    writer.writerow(['Category', 'Keyword', 'Count'])
+
+    for label, value in zip(data['labels'], data['values']):
+        writer.writerow(['document_keywords', label, value])
+
+    return response
+
+
+def export_chats_over_time_csv(request: HttpRequest) -> HttpResponse:
+    """
+    Export chat session statistics over time to a CSV file.
+    """
+    data = get_chats_over_time_stats()
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename=chats_\
+        over_time.csv'
+    writer = csv.writer(response)
+    writer.writerow(['Category', 'Date', 'Count'])
+
+    for label, value in zip(data['labels'], data['values']):
+        writer.writerow(['chats_over_time', label, value])
+
+    return response

--- a/src/core/statistics.py
+++ b/src/core/statistics.py
@@ -1,0 +1,159 @@
+"""
+Generate statistics for the application.
+"""
+from django.db.models.functions import TruncDate
+from django.db.models import Count
+from core import models
+from collections import Counter
+import re
+from typing import List, Dict, Union
+
+
+def get_user_field_of_study_stats() -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics on user fields of study with counts per field.
+    """
+    queryset = models.User.objects.values('field_of_study__name')\
+        .annotate(count=Count('id')).order_by('-count')
+
+    labels = [item['field_of_study__name'] or 'No field' for item in queryset]
+    values = [item['count'] for item in queryset]
+
+    return {
+        "labels": labels,
+        "values": values
+    }
+
+
+def get_most_consulted_documents_stats(
+        limit: int = 10) -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics on the most consulted documents,
+    limited by the given number.
+    """
+    queryset = models.SavedDocument.objects.values('document__title')\
+        .annotate(count=Count('id'))\
+        .order_by('-count')[:limit]
+
+    labels = [item['document__title'] or 'No title' for item in queryset]
+    values = [item['count'] for item in queryset]
+    return {
+        "labels": labels,
+        "values": values
+    }
+
+
+def get_most_consulted_authors_stats(
+        limit: int = 10) -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics on the most consulted authors, based on saved documents.
+    """
+    queryset = models.AuthoredDocument.objects\
+        .filter(document__saveddocument__isnull=False)\
+        .values('author__name') \
+        .annotate(count=Count('document__saveddocument'))\
+        .order_by('-count')[:limit]
+
+    labels = [item['author__name'] or 'No name' for item in queryset]
+    values = [item['count'] for item in queryset]
+
+    return {
+        "labels": labels,
+        "values": values
+    }
+
+
+def get_document_keywords_stats(
+        limit: int = 10) -> Dict[str, List[Union[str, int]]]:
+    """
+    Return keyword frequency statistics extracted from document titles.
+    """
+    documents = models.Document.objects.values_list('title', flat=True)
+    text = ' '.join(documents).lower()
+    words = re.findall(r'\b\w+\b', text)
+
+    stop_words = {"the", "and", "of", "in", "a", "to", "for", "on",
+                  "with", "by", "an", "at", "as", "from", "is", "that",
+                  "this", "it", "or", "are", "was", "be", "not", "but",
+                  "all", "any", "some", "such", "which", "who", "whom",
+                  "el", "la", "los", "las", "de", "que", "en", "del",
+                  "y", "un", "una", "se", "al", "por", "no", "es",
+                  "su", "como", "más", "este", "esta", "este", "estos",
+                  "estas", "todo", "toda", "todos", "todas", "este",
+                  "esta", "estos", "estas", "ese", "esa", "esos",
+                  "esas", "aquel", "aquella", "aquellos", "aquellas", }
+
+    filtered_words = [
+        word for word in words if word not in stop_words and len(word) > 2]
+    most_common = Counter(filtered_words).most_common(limit)
+
+    labels = [word for word, _ in most_common]
+    values = [count for _, count in most_common]
+
+    return {
+        "labels": labels,
+        "values": values
+    }
+
+
+def get_user_education_level_stats() -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics on users' education levels.
+    """
+    queryset = models.User.objects.values('education_level')\
+        .annotate(count=Count('id')).\
+        order_by('-count')
+
+    labels = [models.User.EDUCATION_LEVELS.get(
+        item['education_level'], 'Unknown') for item in queryset]
+    values = [item['count'] for item in queryset]
+    return {"labels": labels, "values": values}
+
+
+def get_user_activity_status_stats() -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics on user activity status (active vs inactive).
+    """
+    queryset = models.User.objects.values(
+        'is_active').annotate(count=Count('id'))
+    labels = ['Active' if item['is_active']
+              else 'Inactive' for item in queryset]
+    values = [item['count'] for item in queryset]
+    return {"labels": labels, "values": values}
+
+
+def get_user_interaction_levels() -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics of users based on number of saved documents.
+    """
+    queryset = models.SavedDocument.objects.values('user__email').annotate(
+        saved_count=Count('id')).order_by('-saved_count')[:10]
+    labels = [item['user__email'] or 'No email' for item in queryset]
+    values = [item['saved_count'] for item in queryset]
+    return {"labels": labels, "values": values}
+
+
+def get_document_status_distribution() -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics on the distribution of document statuses.
+    """
+    queryset = models.Document.objects.values(
+        'status').annotate(count=Count('id'))
+    labels = [models.Document.DOCUMENT_STATUS.get(
+        item['status'], 'Unknown') for item in queryset]
+    values = [item['count'] for item in queryset]
+    return {"labels": labels, "values": values}
+
+
+def get_chats_over_time_stats() -> Dict[str, List[Union[str, int]]]:
+    """
+    Return statistics on number of chat sessions per day over time.
+    """
+    queryset = models.ChatSession.objects.annotate(
+        date=TruncDate('created_at')
+    ).values('date').annotate(count=Count('session_id')).order_by('date')
+
+    labels = [item['date'].strftime("%Y-%m-%d") for item in queryset]
+    values = [item['count'] for item in queryset]
+
+    return {"labels": labels, "values": values}

--- a/src/static/js/admin_stats.js
+++ b/src/static/js/admin_stats.js
@@ -1,0 +1,70 @@
+function createChart(id, label, chartType, data) {
+    const ctx = document.getElementById(id);
+    if (!ctx) return;
+    new Chart(ctx, {
+        type: chartType,
+        data: {
+            labels: data.labels,
+            datasets: [{
+                label: label,
+                data: data.values,
+                backgroundColor: [
+                    "#4e73df",
+                    "#1cc88a",
+                    "#36b9cc",
+                    "#f6c23e",
+                    "#e74a3b",
+                    "#858796",
+                    "#5a5c69",
+                    "#36b9cc",
+                    "#1cc88a",
+                    "#4e73df",
+                    "#f6c23e",
+                    "#e74a3b",
+                    "#858796",
+                    "#5a5c69",
+                ],
+            }]
+        },
+        options: {
+            responsive: true,
+            aspectRatio: 5,
+            plugins: {
+                legend: { display: chartType === "pie" },
+                datalabels: chartType === "pie" ? {
+                    formatter: (value, context) => {
+                        const dataArr = context.chart.data.datasets[0].data;
+                        const total = dataArr.reduce((acc, val) => acc + val, 0);
+                        const percentage = ((value / total) * 100).toFixed(1);
+                        return `${percentage}%`;
+                    },
+                    color: "#fff",
+                    font: {
+                        weight: 'bold'
+                    }
+                } : false
+            }
+        },
+        plugins: chartType === "pie" ? [ChartDataLabels] : []
+    })
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+    const chartsConfig = [
+        { id: "userFieldChart", label: "Field of Study", type: "bar" },
+        { id: "educationLevelChart", label: "Education Level", type: "bar" },
+        { id: "activityStatusChart", label: "Activity Status", type: "pie" },
+        { id: "documentKeywordsChart", label: "Document Keywords", type: "bar" },
+        { id: "documentStatsChart", label: "Document Stats", type: "bar" },
+        { id: "authorStatsChart", label: "Author Stats", type: "bar" },
+        { id: "sessionsByDayChart", label: "Sessions by Day", type: "bar" },
+    ];
+
+    chartsConfig.forEach(({ id, label, type }) => {
+        const el = document.getElementById(id);
+        if (el && el.dataset.chart) {
+            const data = JSON.parse(el.dataset.chart);
+            createChart(id, label, type, data);
+        }
+    });
+});

--- a/src/templates/admin/core/authoreddocument/change_list.html
+++ b/src/templates/admin/core/authoreddocument/change_list.html
@@ -1,0 +1,22 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block content %}
+{{ block.super }}
+
+<div class="module">
+    <h2>Most Consulted Authors</h2>
+    <canvas id="authorStatsChart" width="800" height="200" style="margin-bottom: 50px;"
+        data-chart='{{ author_stats_data|safe }}'></canvas>
+
+    <a href="{% url 'admin:most_consulted_authors_stats_export' %}" class="button" style="margin-bottom: 20px;">Export
+        CSV
+        statistics</a>
+</div>
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{% static 'js/admin_stats.js' %}"></script>
+{% endblock %}

--- a/src/templates/admin/core/chatsession/change_list.html
+++ b/src/templates/admin/core/chatsession/change_list.html
@@ -1,0 +1,22 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block content %}
+{{ block.super }}
+
+<div class="module">
+    <h2>ChatSessions per Day</h2>
+    <canvas id="sessionsByDayChart" style="margin-bottom: 50px;" data-chart='{{ sessions_by_day|safe }}'></canvas>
+
+    <a href="{% url 'admin:chats_over_time_stats_export' %}" class="button" style="margin-bottom: 20px;">Export CSV
+        statistics</a>
+</div>
+
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
+<script src="{% static 'js/admin_stats.js' %}"></script>
+{% endblock %}

--- a/src/templates/admin/core/document/change_list.html
+++ b/src/templates/admin/core/document/change_list.html
@@ -1,0 +1,20 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block content %}
+{{ block.super }}
+<div class="module">
+    <h2>Top Keywords in Document Titles</h2>
+    <canvas id="documentKeywordsChart" width="800" height="200" style="margin-bottom: 50px;"
+        data-chart='{{ document_keywords_data|safe }}'></canvas>
+
+    <a href="{% url 'admin:document_keywords_stats_export' %}" class="button" style="margin-bottom: 20px;">Export CSV
+        statistics</a>
+</div>
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{% static 'js/admin_stats.js' %}"></script>
+{% endblock %}

--- a/src/templates/admin/core/saveddocument/change_list.html
+++ b/src/templates/admin/core/saveddocument/change_list.html
@@ -1,0 +1,21 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block content %}
+{{ block.super }}
+<div class="module">
+    <h2>Most consulted documents</h2>
+    <canvas id="documentStatsChart" width="800" height="200" style="margin-bottom: 50px;""
+    data-chart='{{ document_stats_data|safe }}'></canvas>
+
+    <a href=" {% url 'admin:most_consulted_documents_stats_export' %}" class="button"
+        style="margin-bottom: 20px;">Export CSV
+        statistics</a>
+</div>
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<script src=" https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{% static 'js/admin_stats.js' %}"></script>
+{% endblock %}

--- a/src/templates/admin/core/user/change_list.html
+++ b/src/templates/admin/core/user/change_list.html
@@ -1,0 +1,42 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block content %}
+
+{{ block.super }}
+
+<div class="module">
+    <h2>Users by Field of Study</h2>
+    <canvas id="userFieldChart" width="800" height="200" style="margin-bottom: 50px;"
+        data-chart='{{ user_stats_data|safe }}'></canvas>
+
+    <a href="{% url 'admin:user_field_of_study_stats_export' %}" class="button" style="margin-bottom: 20px;">Export CSV
+        statistics</a>
+</div>
+
+<div class="module">
+    <h2>Users by Education Level</h2>
+    <canvas id="educationLevelChart" width="800" height="200" style="margin-bottom: 50px;"
+        data-chart='{{ user_edu_level_data|safe }}'></canvas>
+
+    <a href="{% url 'admin:user_education_level_stats_export' %}" class="button" style="margin-bottom: 20px;">Export CSV
+        statistics</a>
+</div>
+
+<div class="module">
+    <h2>User Activity Status</h2>
+    <canvas id="activityStatusChart" width="800" height="200" style="margin-bottom: 50px;"
+        data-chart='{{ user_activity_status_data|safe }}'></canvas>
+
+    <a href="{% url 'admin:user_activity_status_stats_export' %}" class="button" style="margin-bottom: 20px;">Export CSV
+        statistics</a>
+</div>
+
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
+<script src="{% static 'js/admin_stats.js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
**Summary of Changes>**
This pull request adds a custom dashboard to the Django Admin panel for displaying key statistics related to users, documents, and authors.

**Key features:**

- User statistics: Displays activity levels, areas of study, and interests.
- Document statistics: Shows most consulted documents and interaction rates.
- Author statistics: Highlights the most consulted authors.
- Keyword and theme statistics: Presents relevant extracted topics.
- Visualizations: Includes interactive charts using Chart.js, styled to match the project's admin theme.
- CSV export: Allows exporting of statistical data for offline analysis.
- Consistent styling with previous admin panel customizations.

**Code Location**
`core/admin.py` ,  `core/statistics.py`, `export_stats.py` , `templates/` and `static/`


**some views of the statistics:**

![image](https://github.com/user-attachments/assets/d6510c70-f83e-4db4-b228-c96b28064fec)

![image](https://github.com/user-attachments/assets/34a2a761-f4d7-4b29-8497-8948ae372af8)

![image](https://github.com/user-attachments/assets/e913ad14-f1c1-4907-ac22-7363964572b1)

![image](https://github.com/user-attachments/assets/60b665aa-8bac-4865-841d-398e6a77cab2)


Fixes #22