### PR TITLE
bugfix/token-auth-csrf-fix: Set TokenAuthentication as default to fix CSRF issue with Angular frontend

### DIFF
--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -140,6 +140,9 @@ AUTH_USER_MODEL = 'core.User'
 
 REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
 }
 
 CORS_ALLOWED_ORIGINS = [


### PR DESCRIPTION
# Summary
When integrating the user API using `TokenAuthentication` with an Angular frontend, the API was still expecting a CSRF token. This was caused by Django REST Framework defaulting to `SessionAuthentication` when not explicitly overridden.
This resulted in a CSRF token missing or incorrect error when calling certain routes (e.g., `POST /api/user/create-anonymous/`).

# change made
Explicitly set the following in settings.py

REST_FRAMEWORK = {
    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
    'DEFAULT_AUTHENTICATION_CLASSES': (
        'rest_framework.authentication.TokenAuthentication',
    ),
}

This ensures the system uses only `TokenAuthentication` by default, preventing CSRF token requirements when using token authentication.

**Tested with Angular frontend requests; CSRF error no longer appears.**
login as user

![Screenshot from 2025-05-16 22-27-27](https://github.com/user-attachments/assets/9b1be654-cab0-4990-995a-2d2e374e9f13)

anonymous user

![Screenshot from 2025-05-16 22-28-41](https://github.com/user-attachments/assets/4e0572b2-31be-4eb4-9a36-aef75740aed8)

Related issue:
Fixes #27

