### PR TITLE
fixed: correct repository uri

### DIFF
--- a/src/core/management/commands/ingest_rf.py
+++ b/src/core/management/commands/ingest_rf.py
@@ -179,7 +179,9 @@ class Command(BaseCommand):
 
                     if handle:
                         repository_uri = (
-                            f"{RI_BASE_URL}/handle/{handle}" if handle else ""
+                            f"{RI_BASE_URL}/xmlui/handle/{handle}"
+                            if handle
+                            else ""
                         )
                     else:
                         repository_uri = ""


### PR DESCRIPTION
The repository uri created in the ingest ragflow pipeline has been corrected. Previously, it was: 
`https://repositorioinstitucional.uaslp.mx//handle/i/<handle value>`

The current correct form is: 
`https://repositorioinstitucional.uaslp.mx/xmlui/handle/i/<handle value>`

fixed: #77 